### PR TITLE
Added 'Tipo_operacion' and 'Datos_operaciones' fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,4 +76,6 @@ $order->save();
 die($TPV->successCode());
 ```
 
-Más información sobre la integración del TPV en https://comercios.ceca.es/docs_constpv/img/manual_comercios.pdf
+Más información sobre la integración del TPV en:
+* https://comercios.ceca.es/docs_constpv/img/manual_comercios.pdf
+* https://comercios.ceca.es/docs_constpv/img/manual_gestor_operaciones.pdf

--- a/src/Ceca/Tpv/Tpv.php
+++ b/src/Ceca/Tpv/Tpv.php
@@ -16,7 +16,7 @@ class Tpv
     );
 
     private $o_required = array('Environment', 'ClaveCifrado', 'MerchantID', 'AcquirerBIN', 'TerminalID', 'TipoMoneda', 'Exponente', 'Cifrado', 'Pago_soportado');
-    private $o_optional = array('Idioma', 'Descripcion', 'URL_OK', 'URL_NOK');
+    private $o_optional = array('Idioma', 'Descripcion', 'URL_OK', 'URL_NOK', 'Tipo_operacion', 'Datos_operaciones');
 
     private $environment = '';
     private $environments = array(
@@ -117,6 +117,8 @@ class Tpv
         $this->setValue($options, 'URL_OK');
         $this->setValue($options, 'URL_NOK');
         $this->setValue($options, 'Descripcion');
+        $this->setValue($options, 'Tipo_operacion');
+        $this->setValue($options, 'Datos_operaciones');
 
         $this->setValueLength('MerchantID', 9);
         $this->setValueLength('AcquirerBIN', 10);
@@ -238,3 +240,4 @@ class Tpv
         return $this->success;
     }
 }
+


### PR DESCRIPTION
If you want to make periodic payments, you need two fields: `Tipo_operacion` and `Datos_operaciones`. I added these fields to optional list so you can set its values with `setOption` method. The values are described in [this document](https://comercios.ceca.es/docs_constpv/img/manual_gestor_operaciones.pdf) (I added this link to README.md).

One important note: after many failures without sense I contacted technical support and they told me that the 2.1 version of technical document has some errors (field names are wrong: `tipoOperacion` and `datosOperacion`) but descriptions to generate field values are ok. I added the right fields and I hope they fix it soon...